### PR TITLE
fix "the the" typo in 'this solution' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ me.
 
 This allows you to transform a link in your markdown into the embedded version
 of that link. It's a [remark](https://remark.js.org/) plugin (the de-facto
-standard markdown parser). You provide a "transformer" the the plugin does the
+standard markdown parser). You provide a "transformer" the plugin does the
 rest.
 
 ## Table of Contents


### PR DESCRIPTION
tiny PR for a tiny typo :)

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: There is a typo I found in the readme where a sentence has "the the" in a sentence, I removed one of them

<!-- Why are these changes necessary? -->

**Why**: seemed easy to fix and obviously the author only intended to write "the" once


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [N/A] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
